### PR TITLE
[skip ci] feat: disable completions at import statement

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,6 +5,7 @@ import * as emmet from '@vscode/emmet-helper'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore
 import type { Configuration } from '../../src/configurationType'
+import isInBannedPosition from './isInBannedPosition'
 
 export = function ({ typescript }: { typescript: typeof import('typescript/lib/tsserverlibrary') }) {
     const ts = typescript
@@ -53,8 +54,7 @@ export = function ({ typescript }: { typescript: typeof import('typescript/lib/t
                 const sourceFile = program?.getSourceFile(fileName)
                 if (!program || !sourceFile) return
                 const scriptSnapshot = info.project.getScriptSnapshot(fileName)
-                const { line, character } = info.languageService.toLineColumnOffset!(fileName, position)
-                if (!scriptSnapshot) return
+                if (!scriptSnapshot || isInBannedPosition(position, fileName, scriptSnapshot, sourceFile, info.languageService)) return
                 let prior = info.languageService.getCompletionsAtPosition(fileName, position, options)
                 // console.log(
                 //     'raw prior',

--- a/typescript/src/isInBannedPosition.ts
+++ b/typescript/src/isInBannedPosition.ts
@@ -1,0 +1,17 @@
+import type tslib from 'typescript/lib/tsserverlibrary'
+
+export default (
+    position: number,
+    fileName: string,
+    scriptSnapshot: tslib.IScriptSnapshot,
+    sourceFile: tslib.SourceFile,
+    languageService: tslib.LanguageService,
+): boolean => {
+    const { character } = languageService.toLineColumnOffset!(fileName, position)
+    const textBeforePositionLine = scriptSnapshot?.getText(position - character, position)
+    const textAfterPosition = scriptSnapshot?.getText(position, sourceFile.getLineEndOfPosition(position))
+    const newLineIndex = textAfterPosition.indexOf('\n')
+    const textAfterPositionLine = newLineIndex === -1 ? textAfterPosition : textAfterPosition.slice(0, newLineIndex)
+    if (textBeforePositionLine.trimStart() === 'import ' && textAfterPositionLine.trimStart().startsWith('from')) return true
+    return false
+}

--- a/typescript/src/isInBannedPosition.ts
+++ b/typescript/src/isInBannedPosition.ts
@@ -9,9 +9,7 @@ export default (
 ): boolean => {
     const { character } = languageService.toLineColumnOffset!(fileName, position)
     const textBeforePositionLine = scriptSnapshot?.getText(position - character, position)
-    const textAfterPosition = scriptSnapshot?.getText(position, sourceFile.getLineEndOfPosition(position))
-    const newLineIndex = textAfterPosition.indexOf('\n')
-    const textAfterPositionLine = newLineIndex === -1 ? textAfterPosition : textAfterPosition.slice(0, newLineIndex)
+    const textAfterPositionLine = scriptSnapshot?.getText(position, sourceFile.getLineEndOfPosition(position))
     if (textBeforePositionLine.trimStart() === 'import ' && textAfterPositionLine.trimStart().startsWith('from')) return true
     return false
 }


### PR DESCRIPTION
Not configurable.
Now we disable completions completely in this position:
```ts
import | from 'some-path'
```
Intention: there is a feature that [suggests default name](https://github.com/zardoy/vscode-experiments/blob/main/src/features/suggestDefaultImportName.ts) for import in exactly this position. TS usually gives gloobal junk in this position.
In unforseeable future probably this functionality can be inlined into this plugin.