### PR TITLE
feat: add `in` keyword completions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -94,6 +94,10 @@ You can quickly disable this plugin functionality by setting this setting to fal
 
 Web-only feature: `import` path resolution
 
+### `in` Keyword Suggestions
+
+[Demo](https://github.com/zardoy/typescript-vscode-plugins/pull/19)
+
 ### Highlight non-function Methods
 
 (*enabled by default*)

--- a/typescript/src/completionsAtPosition.ts
+++ b/typescript/src/completionsAtPosition.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import type tslib from 'typescript/lib/tsserverlibrary'
+import inKeywordCompletions from './inKeywordCompletions'
 // import * as emmet from '@vscode/emmet-helper'
 import isInBannedPosition from './completions/isInBannedPosition'
 import { GetConfig } from './types'
@@ -185,6 +186,17 @@ export const getCompletionsAtPosition = (
             // TODO change to startsWith?
             return !banAutoImportPackages.includes(text)
         })
+
+    const inKeywordCompletionsResult = inKeywordCompletions(position, node, sourceFile, program, languageService)
+    if (inKeywordCompletionsResult) {
+        prior.entries.push(...inKeywordCompletionsResult.completions)
+        Object.assign(
+            prevCompletionsMap,
+            _.mapValues(inKeywordCompletionsResult.docPerCompletion, value => ({
+                documentationOverride: value,
+            })),
+        )
+    }
 
     if (c('suggestions.keywordsInsertText') === 'space') {
         prior.entries = keywordsSpace(prior.entries, scriptSnapshot, position, exactNode)

--- a/typescript/src/inKeywordCompletions.ts
+++ b/typescript/src/inKeywordCompletions.ts
@@ -1,0 +1,67 @@
+export default (position: number, node: ts.Node | undefined, sourceFile: ts.SourceFile, program: ts.Program, languageService: ts.LanguageService) => {
+    if (!node) return
+    function isBinaryExpression(node: ts.Node): node is ts.BinaryExpression {
+        return node.kind === ts.SyntaxKind.BinaryExpression
+    }
+    const typeChecker = program.getTypeChecker()
+    // TODO info diagnostic if used that doesn't exist
+    if (
+        ts.isStringLiteralLike(node) &&
+        isBinaryExpression(node.parent) &&
+        node.parent.left === node &&
+        node.parent.operatorToken.kind === ts.SyntaxKind.InKeyword
+    ) {
+        const quote = node.getText()[0]!
+        const type = typeChecker.getTypeAtLocation(node.parent.right)
+        const suggestionsData = new Map<
+            string,
+            {
+                insertText: string
+                usingDisplayIndexes: number[]
+                documentations: string[]
+            }
+        >()
+        const types = type.isUnion() ? type.types : [type]
+        for (let [typeIndex, typeEntry] of types.entries()) {
+            // improved DX: not breaking other completions as TS would display error anyway
+            if (!(typeEntry.flags & ts.TypeFlags.Object)) continue
+            for (const prop of typeEntry.getProperties()) {
+                const { name } = prop
+                if (!suggestionsData.has(name)) {
+                    suggestionsData.set(name, {
+                        insertText: prop.name.replace(quote, `\\${quote}`),
+                        usingDisplayIndexes: [],
+                        documentations: [],
+                    })
+                }
+                suggestionsData.get(name)!.usingDisplayIndexes.push(typeIndex + 1)
+                // const doc = prop.getDocumentationComment(typeChecker)
+                const declaration = prop.getDeclarations()?.[0]
+                suggestionsData
+                    .get(name)!
+                    .documentations.push(`${typeIndex + 1}: ${declaration && typeChecker.typeToString(typeChecker.getTypeAtLocation(declaration))}`)
+            }
+        }
+        const docPerCompletion: Record<string, string> = {}
+        const maxUsingDisplayIndex = Math.max(...[...suggestionsData.entries()].map(([, { usingDisplayIndexes }]) => usingDisplayIndexes.length))
+        const completions: ts.CompletionEntry[] = [...suggestionsData.entries()]
+            .map(([originaName, { insertText, usingDisplayIndexes, documentations }], i) => {
+                const name = types.length > 1 && usingDisplayIndexes.length === 1 ? `☆${originaName}` : originaName
+                docPerCompletion[name] = documentations.join('\n\n')
+                return {
+                    // ⚀ ⚁ ⚂ ⚃ ⚄ ⚅
+                    name,
+                    kind: ts.ScriptElementKind.string,
+                    insertText,
+                    sourceDisplay: [{ kind: 'text', text: usingDisplayIndexes.join(', ') }],
+                    sortText: `${maxUsingDisplayIndex - usingDisplayIndexes.length}_${i}`,
+                }
+            })
+            .sort((a, b) => a.sortText.localeCompare(b.sortText))
+        return {
+            completions,
+            docPerCompletion,
+        }
+    }
+    return
+}

--- a/typescript/src/utils.ts
+++ b/typescript/src/utils.ts
@@ -137,6 +137,14 @@ export const isWeb = () => {
     }
 }
 
+// spec isnt strict as well
+export const notStrictStringCompletion = (entry: ts.CompletionEntry): ts.CompletionEntry => ({
+    ...entry,
+    // todo
+    name: `◯${entry.name}`,
+    insertText: entry.insertText ?? entry.name,
+})
+
 export function addObjectMethodResultInterceptors<T extends Record<string, any>>(
     object: T,
     interceptors: Partial<{


### PR DESCRIPTION
Don't see a reason too add a setting to disable them. There are awesome!
### Feature Description
Typescript [docs says](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing) that `in` operator is usually used for object type narrowing. Example from the test:
![image](https://user-images.githubusercontent.com/46503702/174466763-d6c1a5b9-d150-45de-801d-3407f14ef9b1.png)
Numbers on right side of the completions means type index (starting from 1) of the union.
When specific key is selected, completion widget displays the type of key in each type of the union.