### PR TITLE
feat(vue-options-api): Add a setting to remove local component definitions

### DIFF
--- a/src/configurationType.ts
+++ b/src/configurationType.ts
@@ -322,6 +322,12 @@ export type Configuration = {
      */
     miscDefinitionImprovement: boolean
     /**
+     * Removes definiion suggestion from vue `components` options.
+     * Might be useful with [Vetur-extended goToDefinition](https://github.com/zardoy/vetur-extended/blob/main/src/gotoDefinition.ts) for components as a replacement for (https://github.com/vuejs/language-tools/issues/1245)
+     * @default false
+     */
+    removeVueComponentsOptionDefinition: boolean
+    /**
      * Experimental, feedback welcome
      * If default, namespace import or import path click resolves to .d.ts file, try to resolve .js file instead with the same name
      * @default false

--- a/typescript/src/definitions.ts
+++ b/typescript/src/definitions.ts
@@ -141,6 +141,9 @@ export default (proxy: ts.LanguageService, languageService: ts.LanguageService, 
                 return true
             })
         }
+        if (c('removeVueComponentsOptionDefinition') && prior.definitions) {
+            prior.definitions = prior.definitions.filter(definition => definition.containerName !== '__VLS_componentsOption')
+        }
 
         if (c('removeModuleFileDefinitions')) {
             prior.definitions = prior.definitions?.filter(def => {


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/74474615/225428612-ccf8bf89-c3b1-4a27-8366-a77d384e863b.mp4

After (if `Vetur Extended is installed):

https://user-images.githubusercontent.com/74474615/225428919-6a8579ba-a79a-400d-be68-8d8a7333eb08.mp4

I would be grateful if you decide to accept this change. This extra definiton is extremely annoying.

Hope `volar` will eventually support [goToSource](https://github.com/vuejs/language-tools/issues/1245) command, but for now I think this is a good replacement. Considered making it enabled by default but it actually depends on `Vetur Extended` for correct work (I don't think that doing nothing is the behaviour is expected as it would be if Vetur Ext. isn't installed), 

