### PR TITLE
fix(volar): update definitions filtering

### DIFF
--- a/typescript/src/definitions.ts
+++ b/typescript/src/definitions.ts
@@ -156,8 +156,22 @@ export default (proxy: ts.LanguageService, languageService: ts.LanguageService, 
                 return true
             })
         }
+
         if (c('removeVueComponentsOptionDefinition') && prior.definitions) {
-            prior.definitions = prior.definitions.filter(definition => definition.containerName !== '__VLS_componentsOption')
+            const program = languageService.getProgram()!
+            const sourceFile = program.getSourceFile(fileName)!
+
+            const lines = sourceFile.getFullText().split('\n')
+            const { line: curLine } = ts.getLineAndCharacterOfPosition(sourceFile, position)
+
+            const VLS_COMPONENT_STRING = `__VLS_templateComponents`
+            const isTemplateComponent = lines[curLine]?.startsWith(VLS_COMPONENT_STRING)
+            if (!isTemplateComponent) return
+
+            const componentName = lines[curLine]?.match(/\.(\w+);?/)?.[1]
+            if (!componentName) return
+
+            prior.definitions = prior.definitions.filter(({ name }) => !(componentName === name && lines[curLine - 2] === '// @ts-ignore'))
         }
 
         return prior

--- a/typescript/src/definitions.ts
+++ b/typescript/src/definitions.ts
@@ -6,7 +6,7 @@ export default (proxy: ts.LanguageService, languageService: ts.LanguageService, 
     proxy.getDefinitionAndBoundSpan = (fileName, position) => {
         const prior = languageService.getDefinitionAndBoundSpan(fileName, position)
 
-        if (c('removeModuleFileDefinitions')) {
+        if (c('removeModuleFileDefinitions') && prior) {
             prior.definitions = prior.definitions?.filter(def => {
                 if (
                     def.kind === ts.ScriptElementKind.moduleElement &&
@@ -21,7 +21,7 @@ export default (proxy: ts.LanguageService, languageService: ts.LanguageService, 
         }
 
         // Definition fallbacks
-        if (!prior || prior.definitions.length === 0) {
+        if (!prior || prior.definitions?.length === 0) {
             const program = languageService.getProgram()!
             const sourceFile = program.getSourceFile(fileName)!
             const node = findChildContainingExactPosition(sourceFile, position)


### PR DESCRIPTION
Resolves #126 

Triggering definitions on the template component gives smth like this:
`__VLS_templateComponents.HelloWorld;`

E.g.
```vue
<template>
  <div id="app">
    <HelloWorld msg="Welcome to Your Vue.js App" />
  </div>
</template>
```

In my tests code in this pr correctly filters out undesired definition