### PR TITLE
feat(refactoring): rename parameter to type name (#107)

### DIFF
--- a/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
+++ b/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
@@ -8,8 +8,10 @@ const getTypeParamName = (parameterIndex: number, functionDeclaration: ts.Node, 
 
     const typeSignatureParams = typeChecker.getSignaturesOfType(type, ts.SignatureKind.Call)[0]?.parameters
     if (!typeSignatureParams) return
+    const typeSignatureParam = typeSignatureParams[parameterIndex]
+    if (!typeSignatureParam) return
 
-    return typeSignatureParams[parameterIndex]!.name
+    return typeSignatureParam.name
 }
 
 const getEdits = (fileName: string, position: number, newText: string, languageService: ts.LanguageService): ts.FileTextChanges[] | undefined => {

--- a/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
+++ b/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
@@ -17,14 +17,15 @@ export default {
         const typeChecker = languageService.getProgram()!.getTypeChecker()
         const type = extractType(typeChecker, functionDecl)
 
-        const typeDecl = type.getSymbol()?.declarations?.[0]
-        if (!typeDecl || !ts.isFunctionLike(typeDecl)) return
+        const typeSignatureParams = typeChecker.getSignaturesOfType(type, ts.SignatureKind.Call)[0]?.parameters
+        if (!typeSignatureParams) return
+
         const paramName = node.getText()
-        const typeParamName = typeDecl.parameters[parameterIndex]!.name.getText()
+        const typeParamName = typeSignatureParams[parameterIndex]!.name
         if (paramName === typeParamName) return
         if (!formatOptions) return true
 
-        const renameLocations = languageService.findRenameLocations(sourceFile.fileName, position, false, false)
+        const renameLocations = languageService.findRenameLocations(sourceFile.fileName, position, false, false, {})
         if (!renameLocations) return
 
         const extractFileName = ({ fileName }: ts.RenameLocation) => fileName

--- a/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
+++ b/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
@@ -1,50 +1,85 @@
 import { pipe, groupBy, map } from 'lodash/fp'
+import { compact } from 'lodash'
 import { CodeAction } from '../getCodeActions'
 import extractType from '../../utils/extractType'
 
-export default {
+const getEdits = (
+    fileName: string,
+    position: number,
+    parameterName: string,
+    parameterIndex: number,
+    functionDeclaration: ts.Node,
+    languageService: ts.LanguageService,
+): ts.FileTextChanges[] | undefined => {
+    const typeChecker = languageService.getProgram()!.getTypeChecker()
+    const type = extractType(typeChecker, functionDeclaration)
+
+    const typeSignatureParams = typeChecker.getSignaturesOfType(type, ts.SignatureKind.Call)[0]?.parameters
+    if (!typeSignatureParams) return
+
+    const typeParamName = typeSignatureParams[parameterIndex]!.name
+    if (parameterName === typeParamName) return
+
+    const renameLocations = languageService.findRenameLocations(fileName, position, false, false, {})
+    if (!renameLocations) return
+
+    const extractFileName = ({ fileName }: ts.RenameLocation) => fileName
+
+    return pipe(
+        groupBy(extractFileName),
+        Object.entries,
+        map(
+            ([fileName, changes]): ts.FileTextChanges => ({
+                fileName,
+                textChanges: changes.map(
+                    ({ textSpan }): ts.TextChange => ({
+                        newText: typeParamName,
+                        span: textSpan,
+                    }),
+                ),
+            }),
+        ),
+    )(renameLocations)
+}
+export const renameParameterToNameFromType = {
     id: 'renameParameterToNameFromType',
     name: 'Rename Parameter to Name from Type',
     kind: 'refactor.rewrite.renameParameterToNameFromType',
     tryToApply(sourceFile, position, range, node, formatOptions, languageService) {
         if (!node || !position) return
-        if (!ts.isIdentifier(node) || !ts.isParameter(node.parent) || !ts.isFunctionLike(node.parent.parent)) return
+        const functionSignature = node.parent.parent
+        if (!ts.isIdentifier(node) || !ts.isParameter(node.parent) || !ts.isFunctionLike(functionSignature)) return
 
-        const functionParameters = node.parent.parent.parameters
-        const parameterIndex = functionParameters.indexOf(node.parent)
-
-        const functionDecl = node.parent.parent.parent
-        const typeChecker = languageService.getProgram()!.getTypeChecker()
-        const type = extractType(typeChecker, functionDecl)
-
-        const typeSignatureParams = typeChecker.getSignaturesOfType(type, ts.SignatureKind.Call)[0]?.parameters
-        if (!typeSignatureParams) return
-
-        const paramName = node.getText()
-        const typeParamName = typeSignatureParams[parameterIndex]!.name
-        if (paramName === typeParamName) return
         if (!formatOptions) return true
 
-        const renameLocations = languageService.findRenameLocations(sourceFile.fileName, position, false, false, {})
-        if (!renameLocations) return
+        const { parent: functionDecl, parameters: functionParameters } = functionSignature
+        const parameterIndex = functionParameters.indexOf(node.parent)
+        const parameterName = functionParameters[parameterIndex]!.name.getText()
 
-        const extractFileName = ({ fileName }: ts.RenameLocation) => fileName
-        const edits = pipe(
-            groupBy(extractFileName),
-            Object.entries,
-            map(
-                ([fileName, changes]): ts.FileTextChanges => ({
-                    fileName,
-                    textChanges: changes.map(
-                        ({ textSpan }): ts.TextChange => ({
-                            newText: typeParamName,
-                            span: textSpan,
-                        }),
-                    ),
-                }),
-            ),
-        )(renameLocations)
+        const edits = compact(getEdits(sourceFile.fileName, position, parameterName, parameterIndex, functionDecl, languageService))
+        return {
+            edits,
+        }
+    },
+} satisfies CodeAction
 
+export const renameAllParametersToNameFromType = {
+    id: 'renameAllParametersToNameFromType',
+    name: 'Rename All Parameters to Name from Type',
+    kind: 'refactor.rewrite.renameAllParametersToNameFromType',
+    tryToApply(sourceFile, position, range, node, formatOptions, languageService) {
+        if (!node || !position) return
+        const functionSignature = node.parent.parent
+        if (!ts.isIdentifier(node) || !ts.isParameter(node.parent) || !ts.isFunctionLike(functionSignature)) return
+        if (!formatOptions) return true
+
+        const { parent: functionDecl, parameters: functionParameters } = functionSignature
+
+        const edits = compact(
+            functionParameters.flatMap((param, index) => {
+                return getEdits(sourceFile.fileName, param.end, param.getText(), index, functionDecl, languageService)
+            }),
+        )
         return {
             edits,
         }

--- a/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
+++ b/typescript/src/codeActions/custom/renameParameterToNameFromType.ts
@@ -3,9 +3,9 @@ import { CodeAction } from '../getCodeActions'
 import extractType from '../../utils/extractType'
 
 export default {
-    id: 'renameToTypeParameter',
+    id: 'renameParameterToNameFromType',
     name: 'Rename Parameter to Name from Type',
-    kind: 'refactor.rewrite.renameToTypeParameter',
+    kind: 'refactor.rewrite.renameParameterToNameFromType',
     tryToApply(sourceFile, position, range, node, formatOptions, languageService) {
         if (!node || !position) return
         if (!ts.isIdentifier(node) || !ts.isParameter(node.parent) || !ts.isFunctionLike(node.parent.parent)) return
@@ -24,9 +24,7 @@ export default {
         if (paramName === typeParamName) return
         if (!formatOptions) return true
 
-        const renameLocations = languageService.findRenameLocations(sourceFile.fileName, position, false, false, {
-            providePrefixAndSuffixTextForRename: false,
-        })
+        const renameLocations = languageService.findRenameLocations(sourceFile.fileName, position, false, false)
         if (!renameLocations) return
 
         const extractFileName = ({ fileName }: ts.RenameLocation) => fileName

--- a/typescript/src/codeActions/custom/renameToTypeParameter.ts
+++ b/typescript/src/codeActions/custom/renameToTypeParameter.ts
@@ -4,7 +4,7 @@ import extractType from '../../utils/extractType'
 
 export default {
     id: 'renameToTypeParameter',
-    name: 'Rename to Type Parameter',
+    name: 'Rename Parameter to Name from Type',
     kind: 'refactor.rewrite.renameToTypeParameter',
     tryToApply(sourceFile, position, range, node, formatOptions, languageService) {
         if (!node || !position) return

--- a/typescript/src/codeActions/custom/renameToTypeParameter.ts
+++ b/typescript/src/codeActions/custom/renameToTypeParameter.ts
@@ -1,0 +1,36 @@
+import { CodeAction } from '../getCodeActions'
+import { getChangesTracker } from '../../utils'
+
+export default {
+    id: 'renameToTypeParameter',
+    name: 'Rename to Type Parameter',
+    kind: 'refactor.rewrite.renameToTypeParameter',
+    tryToApply(sourceFile, position, range, node, formatOptions, languageService) {
+        if (!node || !position) return
+        if (!ts.isIdentifier(node) || !ts.isParameter(node.parent) || !ts.isFunctionLike(node.parent.parent)) return
+
+        const functionParameters = node.parent.parent.parameters
+        const parameterIndex = functionParameters.indexOf(node.parent)
+
+        const functionDecl = node.parent.parent.parent
+        const typeChecker = languageService.getProgram()!.getTypeChecker()
+        const typeAtLocation = typeChecker.getTypeAtLocation(functionDecl)
+
+        const typeDecl = typeAtLocation.getSymbol()?.declarations?.[0]
+        if (!typeDecl || !ts.isFunctionLike(typeDecl)) return
+        const paramName = node.getText()
+        const typeParamName = typeDecl.parameters[parameterIndex]!.name.getText()
+        if (paramName === typeParamName) return
+        if (!formatOptions) return true
+        const changesTracker = getChangesTracker({})
+        changesTracker.replaceNodeWithText(sourceFile, node, typeParamName)
+        return {
+            edits: [
+                {
+                    fileName: sourceFile.fileName,
+                    textChanges: changesTracker.getChanges()[0]!.textChanges,
+                },
+            ],
+        }
+    },
+} satisfies CodeAction

--- a/typescript/src/codeActions/custom/renameToTypeParameter.ts
+++ b/typescript/src/codeActions/custom/renameToTypeParameter.ts
@@ -1,5 +1,6 @@
 import { pipe, groupBy, map } from 'lodash/fp'
 import { CodeAction } from '../getCodeActions'
+import extractType from '../../utils/extractType'
 
 export default {
     id: 'renameToTypeParameter',
@@ -14,9 +15,9 @@ export default {
 
         const functionDecl = node.parent.parent.parent
         const typeChecker = languageService.getProgram()!.getTypeChecker()
-        const typeAtLocation = typeChecker.getTypeAtLocation(functionDecl)
+        const type = extractType(typeChecker, functionDecl)
 
-        const typeDecl = typeAtLocation.getSymbol()?.declarations?.[0]
+        const typeDecl = type.getSymbol()?.declarations?.[0]
         if (!typeDecl || !ts.isFunctionLike(typeDecl)) return
         const paramName = node.getText()
         const typeParamName = typeDecl.parameters[parameterIndex]!.name.getText()

--- a/typescript/src/codeActions/getCodeActions.ts
+++ b/typescript/src/codeActions/getCodeActions.ts
@@ -6,9 +6,9 @@ import objectSwapKeysAndValues from './custom/objectSwapKeysAndValues'
 import changeStringReplaceToRegex from './custom/changeStringReplaceToRegex'
 import splitDeclarationAndInitialization from './custom/splitDeclarationAndInitialization'
 import addMissingProperties from './extended/addMissingProperties'
-import renameToTypeParameter from './custom/renameToTypeParameter'
+import renameParameterToNameFromType from './custom/renameParameterToNameFromType'
 
-const codeActions: CodeAction[] = [objectSwapKeysAndValues, changeStringReplaceToRegex, splitDeclarationAndInitialization, renameToTypeParameter]
+const codeActions: CodeAction[] = [objectSwapKeysAndValues, changeStringReplaceToRegex, splitDeclarationAndInitialization, renameParameterToNameFromType]
 const extendedCodeActions: ExtendedCodeAction[] = [addMissingProperties]
 
 type SimplifiedRefactorInfo =

--- a/typescript/src/codeActions/getCodeActions.ts
+++ b/typescript/src/codeActions/getCodeActions.ts
@@ -6,9 +6,15 @@ import objectSwapKeysAndValues from './custom/objectSwapKeysAndValues'
 import changeStringReplaceToRegex from './custom/changeStringReplaceToRegex'
 import splitDeclarationAndInitialization from './custom/splitDeclarationAndInitialization'
 import addMissingProperties from './extended/addMissingProperties'
-import renameParameterToNameFromType from './custom/renameParameterToNameFromType'
+import { renameParameterToNameFromType, renameAllParametersToNameFromType } from './custom/renameParameterToNameFromType'
 
-const codeActions: CodeAction[] = [objectSwapKeysAndValues, changeStringReplaceToRegex, splitDeclarationAndInitialization, renameParameterToNameFromType]
+const codeActions: CodeAction[] = [
+    objectSwapKeysAndValues,
+    changeStringReplaceToRegex,
+    splitDeclarationAndInitialization,
+    renameParameterToNameFromType,
+    renameAllParametersToNameFromType,
+]
 const extendedCodeActions: ExtendedCodeAction[] = [addMissingProperties]
 
 type SimplifiedRefactorInfo =

--- a/typescript/src/codeActions/getCodeActions.ts
+++ b/typescript/src/codeActions/getCodeActions.ts
@@ -6,8 +6,9 @@ import objectSwapKeysAndValues from './custom/objectSwapKeysAndValues'
 import changeStringReplaceToRegex from './custom/changeStringReplaceToRegex'
 import splitDeclarationAndInitialization from './custom/splitDeclarationAndInitialization'
 import addMissingProperties from './extended/addMissingProperties'
+import renameToTypeParameter from './custom/renameToTypeParameter'
 
-const codeActions: CodeAction[] = [objectSwapKeysAndValues, changeStringReplaceToRegex, splitDeclarationAndInitialization]
+const codeActions: CodeAction[] = [objectSwapKeysAndValues, changeStringReplaceToRegex, splitDeclarationAndInitialization, renameToTypeParameter]
 const extendedCodeActions: ExtendedCodeAction[] = [addMissingProperties]
 
 type SimplifiedRefactorInfo =

--- a/typescript/src/constructMethodSnippet.ts
+++ b/typescript/src/constructMethodSnippet.ts
@@ -2,6 +2,7 @@ import { compact, oneOf } from '@zardoy/utils'
 import { isTypeNode } from './completions/keywordsSpace'
 import { GetConfig } from './types'
 import { findChildContainingExactPosition } from './utils'
+import extractType from './utils/extractType'
 
 // todo-low-ee inspect any last arg infer
 export default (
@@ -17,11 +18,9 @@ export default (
 ) => {
     let containerNode = findChildContainingExactPosition(sourceFile, position)
     if (!containerNode || isTypeNode(containerNode)) return
-
     const checker = languageService.getProgram()!.getTypeChecker()!
-    let type = symbol ? checker.getTypeOfSymbol(symbol) : checker.getTypeAtLocation(containerNode)
-    // give another chance
-    if (symbol && type['intrinsicName'] === 'error') type = checker.getTypeOfSymbolAtLocation(symbol, containerNode)
+
+    const type = extractType(checker, symbol, containerNode)
 
     if (ts.isIdentifier(containerNode)) containerNode = containerNode.parent
     if (ts.isPropertyAccessExpression(containerNode)) containerNode = containerNode.parent

--- a/typescript/src/constructMethodSnippet.ts
+++ b/typescript/src/constructMethodSnippet.ts
@@ -20,7 +20,7 @@ export default (
     if (!containerNode || isTypeNode(containerNode)) return
     const checker = languageService.getProgram()!.getTypeChecker()!
 
-    const type = extractType(checker, symbol, containerNode)
+    const type = extractType(checker, containerNode, symbol)
 
     if (ts.isIdentifier(containerNode)) containerNode = containerNode.parent
     if (ts.isPropertyAccessExpression(containerNode)) containerNode = containerNode.parent

--- a/typescript/src/utils/extractType.ts
+++ b/typescript/src/utils/extractType.ts
@@ -1,4 +1,4 @@
-export default (typeChecker: ts.TypeChecker, symbol: ts.Symbol | undefined, node: ts.Node) => {
+export default (typeChecker: ts.TypeChecker, node: ts.Node, symbol?: ts.Symbol) => {
     const type = symbol ? typeChecker.getTypeOfSymbol(symbol) : typeChecker.getTypeAtLocation(node)
     // give another chance
     if (symbol && type['intrinsicName'] === 'error') return typeChecker.getTypeOfSymbolAtLocation(symbol, node)

--- a/typescript/src/utils/extractType.ts
+++ b/typescript/src/utils/extractType.ts
@@ -1,0 +1,6 @@
+export default (typeChecker: ts.TypeChecker, symbol: ts.Symbol | undefined, node: ts.Node) => {
+    const type = symbol ? typeChecker.getTypeOfSymbol(symbol) : typeChecker.getTypeAtLocation(node)
+    // give another chance
+    if (symbol && type['intrinsicName'] === 'error') return typeChecker.getTypeOfSymbolAtLocation(symbol, node)
+    return type
+}


### PR DESCRIPTION
Resolves #107 
@zardoy Is there a way to rename all param occurrences within a function body (like vscode's  `Rename symbol` command works)?

I tested on this code:
```ts
type fnType = (name: number) => number;

const fn1: fnType = (arg): number => arg

const fn2: fnType = function fn2(arg: number): number {
  return arg
}
```