### PR TITLE
fix(volar): prevent semantic server crushes in new versions 

### DIFF
--- a/typescript/src/decorateProxy.ts
+++ b/typescript/src/decorateProxy.ts
@@ -92,9 +92,7 @@ export const decorateLanguageService = (
             prevCompletionsAdditionalData = result.prevCompletionsAdditionalData
             return result.completions
         } catch (err) {
-            setTimeout(() => {
-                throw err as Error
-            })
+            console.error(err)
             return {
                 entries: [
                     {


### PR DESCRIPTION
Resolves #191 

Ofc this issue is reproducible with local build too. I didn't find out why this exceptions is thrown, but I think replacing `throw` with `console.error` should be good.