### PR TITLE
fix(tests): `expected` and `received` results are mixed up

### DIFF
--- a/typescript/test/testing.ts
+++ b/typescript/test/testing.ts
@@ -178,7 +178,7 @@ export const fourslashLikeTester = (contents: string, fileName = entrypoint, { d
                     )!
                     const newContentsActual = tsFull.textChanges.applyChanges(getCurrentFile(), edits[0]!.textChanges)
                     if (newContent) {
-                        expect(dedentString(newContent), `at marker ${mark}`).toEqual(newContentsActual)
+                        expect(newContentsActual, `at marker ${mark}`).toEqual(dedentString(newContent))
                     }
                     return newContentsActual
                 }


### PR DESCRIPTION
You can see the bug here: https://github.com/zardoy/typescript-vscode-plugins/actions/runs/7950003246/job/21701805850#step:9:30

Or on this screenshot (`received` should be `expected` and vice versa):
![image](https://github.com/zardoy/typescript-vscode-plugins/assets/74474615/f476ead0-c34e-4ba7-b5bf-ad545f446f08)
