### PR TITLE
fix(addDestructure): support call expression argument destructuring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "develop"
     ],
     "cSpell.words": [
+        "fourslash",
         "tsserverlibrary",
         "unpatch"
     ],

--- a/typescript/src/codeActions/custom/addDestructure/addSplittedDestructure.ts
+++ b/typescript/src/codeActions/custom/addDestructure/addSplittedDestructure.ts
@@ -19,13 +19,13 @@ export default (node: ts.Node, sourceFile: ts.SourceFile, formatOptions: ts.Form
         const highlightedNode = findChildContainingExactPosition(sourceFile, pos)
 
         if (!highlightedNode) continue
+        /**
+         * Targets `/->/foo.map/<-/(newVariable.test)`
+         */
+        const isInsideExpressionOfCallExpression =
+            ts.isCallExpression(highlightedNode.parent.parent) && highlightedNode.parent.parent.expression === highlightedNode.parent
 
-        if (
-            ts.isElementAccessExpression(highlightedNode.parent) ||
-            ts.isCallExpression(highlightedNode.parent.parent) ||
-            ts.isTypeQueryNode(highlightedNode.parent)
-        )
-            return
+        if (ts.isElementAccessExpression(highlightedNode.parent) || ts.isTypeQueryNode(highlightedNode.parent) || isInsideExpressionOfCallExpression) return
 
         if (ts.isIdentifier(highlightedNode) && ts.isPropertyAccessExpression(highlightedNode.parent)) {
             const accessorName = highlightedNode.parent.name.getText()

--- a/typescript/test/codeActions/addDestruct.spec.ts
+++ b/typescript/test/codeActions/addDestruct.spec.ts
@@ -254,8 +254,31 @@ describe('Add destructure', () => {
         })
     })
 
+    test('Adds destructure to argument of call expression', () => {
+        const initial = /* ts */ `
+              const /*t*/newVariable/*t*/ = { test: 1 }
+
+              const obj = {
+                  tag: foo.map(newVariable.test),
+              }
+            `
+        const expected = /* ts */ `
+              const { test } = { test: 1 }
+
+              const obj = {
+                  tag: foo.map(test),
+              }
+            `
+
+        const { codeAction } = fourslashLikeTester(initial, undefined, { dedent: true })
+
+        codeAction(0, {
+            refactorName: 'Add Destruct',
+            newContent: expected,
+        })
+    })
     describe('Skip cases', () => {
-        test('Should skip if trying to destruct call expression', () => {
+        test('Should skip if trying to destruct expression of call expression', () => {
             const initial = /* ts */ `
               const /*t*/newVariable/*t*/ = foo
 


### PR DESCRIPTION
Changes:
* Support destructuring of call expression arguments (See tests for example)

These changes were cherry-picked and slightly modified from https://github.com/zardoy/typescript-vscode-plugins/pull/202/commits/4ae4e527ba230797fc71de4f50c96c4843d53a8e. It doesn't make sense to keep this small fix in a Vue-related PR. 